### PR TITLE
add setProgress call that includes animation duration in milliseconds

### DIFF
--- a/circularfillableloaders/src/main/java/com/mikhaellopez/circularfillableloaders/CircularFillableLoaders.java
+++ b/circularfillableloaders/src/main/java/com/mikhaellopez/circularfillableloaders/CircularFillableLoaders.java
@@ -365,6 +365,16 @@ public class CircularFillableLoaders extends ImageView {
         animatorSetProgress.play(waterLevelAnim);
         animatorSetProgress.start();
     }
+
+    public void setProgress(int progress, int milliseconds) {
+        // vertical animation.
+        ObjectAnimator waterLevelAnim = ObjectAnimator.ofFloat(this, "waterLevelRatio", waterLevelRatio, 1f - ((float) progress / 100));
+        waterLevelAnim.setDuration(milliseconds);
+        waterLevelAnim.setInterpolator(new DecelerateInterpolator());
+        AnimatorSet animatorSetProgress = new AnimatorSet();
+        animatorSetProgress.play(waterLevelAnim);
+        animatorSetProgress.start();
+    }
     //endregion
 
     //region Animation


### PR DESCRIPTION
i wanted to emulate the animation used in your example app when seekBarProgress changes. but i wanted to control the animation duration instead of using the default 1000 milliseconds. in my case, i'm setting a runnable and setting the progress between 0 and 100 every five seconds:

![animation](https://cloud.githubusercontent.com/assets/530852/23049457/229057c0-f471-11e6-8242-2c7d14594382.gif)

to achieve this i needed to call not just `setProgress(100)` but a new function that accepts a duration parameter in milliseconds: `setProgress(100, 5000)`.

let me know what you think.